### PR TITLE
#2 add response status code as tag on request failure events

### DIFF
--- a/locust_influxdb_listener/__init__.py
+++ b/locust_influxdb_listener/__init__.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from influxdb import InfluxDBClient
 from locust.exception import InterruptTaskSet
+from requests.exceptions import HTTPError
 import locust.env
 
 
@@ -146,6 +147,10 @@ class InfluxDBListener:
             'success': success,
             'exception': repr(exception),
         }
+
+        if isinstance(exception, HTTPError):
+            tags['code'] = exception.response.status_code
+
         fields = {
             'response_time': response_time,
             'response_length': response_length,


### PR DESCRIPTION
Adding code so that when a request failure is received it will check if the exception is an HTTPError (which should be the case most of the time).

then it add in that case a tag 'code' with the response status code information.

